### PR TITLE
Climbing test

### DIFF
--- a/mse2202-project/climb.h
+++ b/mse2202-project/climb.h
@@ -74,7 +74,7 @@ void startClimb() {
 
 void handleClimb() {
   current = analogRead(ciCurrentSensor);
-  Serial.printf("Current: %d\n", current);
+//  Serial.printf("Current: %d\n", current);
   
   if (current >= currentThreshold) {
     currentChangeTime = 0;
@@ -84,7 +84,7 @@ void handleClimb() {
     currentChangeTime = millis() + currentStallTime;
   } 
   
-  switch (climbStateTime) {
+  switch (curClimbState) {
     case STOPPED:
       climb(0);
       break;

--- a/mse2202-project/climb.h
+++ b/mse2202-project/climb.h
@@ -1,0 +1,104 @@
+#ifndef CLIMB_H
+#define CLIMB_H 1
+
+const int holdPower = 0;
+
+int current = 0;
+long currentChangeTime = 0;
+const int currentThreshold = 1750;
+const int currentStallTime = 250; 
+
+enum climbState {
+  STOPPED = 0,
+  UP,
+  DOWN,
+  HOLD
+};
+
+unsigned long climbStateTime = 0;
+climbState prevClimbState = STOPPED;
+climbState curClimbState = STOPPED;
+
+void changeState(climbState nextState) {
+  prevClimbState = curClimbState;
+  curClimbState = nextState;
+
+  switch (curClimbState) {
+    case STOPPED:
+      Serial.printf("Switched state to STOPPED, took %lu time\n", millis() - driveStateTime);
+      driveManeuverIndex = 0;
+      break;
+    case UP:
+      Serial.printf("Switched state to UP, took %lu time\n", millis() - driveStateTime);
+      break;
+    case DOWN:
+      Serial.printf("Switched state to DOWN, took %lu time\n", millis() - driveStateTime);
+      break;
+    case HOLD:
+      Serial.printf("Switched state to HOLD, took %lu time\n", millis() - driveStateTime);
+      break;
+  }
+
+  driveStateTime = millis();
+}
+
+void setupClimb() {
+  pinMode(ciCurrentSensor, INPUT); // Current sensor
+
+  ledcAttachPin(ciMotorClimbA, 5); // assign Motors pins to channels
+  ledcAttachPin(ciMotorClimbB, 6);
+
+  ledcSetup(5, 20000, 8); // 20mS PWM, 8-bit resolution
+  ledcSetup(6, 20000, 8);
+}
+
+void climb(int power) {
+  if (power > 0) {
+    ledcWrite(5, power);
+    ledcWrite(6, 0);
+  } else if (power < 0) {
+    ledcWrite(5, 0);
+    ledcWrite(6, power);
+  } else {
+    ledcWrite(5, 0);
+    ledcWrite(6, 0);
+  }
+}
+
+void stopClimb() {
+  changeState(STOPPED);
+}
+
+void startClimb() {
+  changeState(UP);
+}
+
+void handleClimb() {
+  current = analogRead(ciCurrentSensor);
+  Serial.printf("Current: %d\n", current);
+  
+  if (current >= currentThreshold) {
+    currentChangeTime = 0;
+  } else if (currentChangeTime != 0 && millis() > currentChangeTime) {
+    changeState(HOLD);
+  } else if (currentChangeTime == 0 && current < currentThreshold) {
+    currentChangeTime = millis() + currentStallTime;
+  } 
+  
+  switch (curDriveState) {
+    case STOPPED:
+      climb(0);
+      break;
+    case UP:
+      climb(255);
+      break;
+    case DOWN:
+      climb(-255);
+      break;
+    case HOLD:
+      climb(holdPower);
+      break;
+  }
+}
+
+#endif

--- a/mse2202-project/climb.h
+++ b/mse2202-project/climb.h
@@ -2,11 +2,14 @@
 #define CLIMB_H 1
 
 const int holdPower = 0;
+const int upPower = 255;
+const int downPower = 100;
+const long holdTime = 10000;
 
 int current = 0;
 long currentChangeTime = 0;
-const int currentThreshold = 1750;
-const int currentStallTime = 250; 
+const long currentThreshold = 1750;
+const long currentStallTime = 250; 
 
 enum climbState {
   STOPPED = 0,
@@ -89,13 +92,15 @@ void handleClimb() {
       climb(0);
       break;
     case UP:
-      climb(255);
+      climb(upPower);
       break;
     case DOWN:
-      climb(-255);
+      climb(-downPower);
       break;
     case HOLD:
       climb(holdPower);
+      if (millis() > climbStateTime + holdTime)
+        changeClimbState(DOWN);
       break;
   }
 }

--- a/mse2202-project/climb.h
+++ b/mse2202-project/climb.h
@@ -19,27 +19,26 @@ unsigned long climbStateTime = 0;
 climbState prevClimbState = STOPPED;
 climbState curClimbState = STOPPED;
 
-void changeState(climbState nextState) {
+void changeClimbState(climbState nextState) {
   prevClimbState = curClimbState;
   curClimbState = nextState;
 
   switch (curClimbState) {
     case STOPPED:
-      Serial.printf("Switched state to STOPPED, took %lu time\n", millis() - driveStateTime);
-      driveManeuverIndex = 0;
+      Serial.printf("Switched state to STOPPED, took %lu time\n", millis() - climbStateTime);
       break;
     case UP:
-      Serial.printf("Switched state to UP, took %lu time\n", millis() - driveStateTime);
+      Serial.printf("Switched state to UP, took %lu time\n", millis() - climbStateTime);
       break;
     case DOWN:
-      Serial.printf("Switched state to DOWN, took %lu time\n", millis() - driveStateTime);
+      Serial.printf("Switched state to DOWN, took %lu time\n", millis() - climbStateTime);
       break;
     case HOLD:
-      Serial.printf("Switched state to HOLD, took %lu time\n", millis() - driveStateTime);
+      Serial.printf("Switched state to HOLD, took %lu time\n", millis() - climbStateTime);
       break;
   }
 
-  driveStateTime = millis();
+  climbStateTime = millis();
 }
 
 void setupClimb() {
@@ -66,11 +65,11 @@ void climb(int power) {
 }
 
 void stopClimb() {
-  changeState(STOPPED);
+  changeClimbState(STOPPED);
 }
 
 void startClimb() {
-  changeState(UP);
+  changeClimbState(UP);
 }
 
 void handleClimb() {
@@ -80,12 +79,12 @@ void handleClimb() {
   if (current >= currentThreshold) {
     currentChangeTime = 0;
   } else if (currentChangeTime != 0 && millis() > currentChangeTime) {
-    changeState(HOLD);
+    changeClimbState(HOLD);
   } else if (currentChangeTime == 0 && current < currentThreshold) {
     currentChangeTime = millis() + currentStallTime;
   } 
   
-  switch (curDriveState) {
+  switch (climbStateTime) {
     case STOPPED:
       climb(0);
       break;

--- a/mse2202-project/drive.h
+++ b/mse2202-project/drive.h
@@ -120,6 +120,11 @@ void toggleDrive() {
   }
 }
 
+bool readyToClimb() {
+  if (driveManeuverIndex == nDriveManeuvers - 1)
+    return true;
+}
+
 bool driveTo(int cmTarget) {
   target = cmToEnc(cmTarget);
   int& distError = error1;

--- a/mse2202-project/mse2202-project.ino
+++ b/mse2202-project/mse2202-project.ino
@@ -1,9 +1,47 @@
-void setup() {
-  // put your setup code here, to run once:
+/* Sensor Pins */
+const int buttonPin = 27;
 
+/* Motor Pins */
+const int climbMotorFPin = 15;
+const int climbMotorRPin = 2;
+
+/* Sensor State/Time Variables */
+int button = 1;
+int buttonLast = 1;
+
+/* Motor State/Time Variables */
+bool motorOn = false;
+
+void setup() {
+   // Sensor pin setup
+   pinMode(buttonPin, INPUT_PULLUP);
+  
+   // ledc (LED Control) pins setup, used as PWMs for motors
+   ledcAttachPin(climbMotorFPin, 1); // F means forward
+   ledcAttachPin(climbMotorRPin, 2); // R means reverse
+   ledcSetup(1, 20000, 8);
+   ledcSetup(2, 20000, 8);
+
+   Serial.begin(115200);
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
+  Serial.print("Button: ");
+  Serial.print(button);
+  Serial.print(" Motor: ");
+  Serial.println(motorOn);
+  
+  button = digitalRead(buttonPin);
+  if (button == 1 && buttonLast == 0) // Button has just been pressed
+    motorOn = !motorOn;               // Turn the motor on if off, turn motor off if on
 
+  if (motorOn) {
+    ledcWrite(1, 255);
+    ledcWrite(2, 0);
+  } else {
+    ledcWrite(1, 0);
+    ledcWrite(2, 0);
+  }
+
+  buttonLast = button;
 }

--- a/mse2202-project/mse2202-project.ino
+++ b/mse2202-project/mse2202-project.ino
@@ -47,8 +47,8 @@ const int ciMotorLeftA = 4;
 const int ciMotorLeftB = 18;
 const int ciMotorRightA = 19;
 const int ciMotorRightB = 12;
-const int ciMotorClimbA = 15;
-const int ciMotorClimbB = 2;
+const int ciMotorClimbA = 25;
+const int ciMotorClimbB = 23;
 
 const int ciEncoderLeftA = 5;
 const int ciEncoderLeftB = 17;
@@ -80,6 +80,7 @@ void setup() {
 }
 
 void loop() {
+  Serial.printf("built in: %d", LED_BUILTIN);
   curButtonState = digitalRead(ciPB1);
   ENC_Averaging(); //average the encoder tick times
 
@@ -88,12 +89,13 @@ void loop() {
     toggleDrive();
     stopClimb();
   }
-  
+
   handleDrive();
-  if (readyToClimb())
+  if (readyToClimb()) {
     startClimb();
+  }
   handleClimb();
-  
+
   prevButtonState = curButtonState;
-  delay(3);
+  delay(1);
 }

--- a/mse2202-project/mse2202-project.ino
+++ b/mse2202-project/mse2202-project.ino
@@ -3,9 +3,11 @@ const int buttonPin = 27;
 const int potiPin = 32;
 const int currentSensorPin = A5;
 
-/* Motor Pins */
+/* Motor Pins and Channels */
 const int climbMotorFPin = 15;
 const int climbMotorRPin = 2;
+const int climbMotorFChannel = 1;
+const int climbMotorRChannel = 2;
 
 /* Sensor State/Time Variables */
 int button = 1;
@@ -31,8 +33,8 @@ void setup() {
    pinMode(currentSensorPin, INPUT); // Current sensor
   
    // ledc (LED Control) pins setup, used as PWMs for motors
-   ledcAttachPin(climbMotorFPin, 1); // F means forward
-   ledcAttachPin(climbMotorRPin, 2); // R means reverse
+   ledcAttachPin(climbMotorFPin, climbMotorFChannel); // F means forward
+   ledcAttachPin(climbMotorRPin, climbMotorRChannel); // R means reverse
    ledcSetup(1, 20000, 8);
    ledcSetup(2, 20000, 8);
 
@@ -59,11 +61,11 @@ void loop() {
   } 
 
   if (motorOn) {
-    ledcWrite(1, motorSpeed);
-    ledcWrite(2, 0);
+    ledcWrite(climbMotorFChannel, motorSpeed);
+    ledcWrite(climbMotorRChannel, 0);
   } else {
-    ledcWrite(1, 0);
-    ledcWrite(2, 0);
+    ledcWrite(climbMotorFChannel, 0);
+    ledcWrite(climbMotorRChannel, 0);
   }
 
   buttonLast = button;

--- a/mse2202-project/mse2202-project.ino
+++ b/mse2202-project/mse2202-project.ino
@@ -80,7 +80,6 @@ void setup() {
 }
 
 void loop() {
-  Serial.printf("built in: %d", LED_BUILTIN);
   curButtonState = digitalRead(ciPB1);
   ENC_Averaging(); //average the encoder tick times
 

--- a/mse2202-project/mse2202-project.ino
+++ b/mse2202-project/mse2202-project.ino
@@ -1,5 +1,6 @@
 /* Sensor Pins */
 const int buttonPin = 27;
+const int potiPin = 32;
 
 /* Motor Pins */
 const int climbMotorFPin = 15;
@@ -8,13 +9,18 @@ const int climbMotorRPin = 2;
 /* Sensor State/Time Variables */
 int button = 1;
 int buttonLast = 1;
+int poti = 0;
 
 /* Motor State/Time Variables */
 bool motorOn = false;
+const int minMotorSpeed = 150;
+const int maxMotorSpeed = 255;
+int motorSpeed = 0;
 
 void setup() {
    // Sensor pin setup
    pinMode(buttonPin, INPUT_PULLUP);
+   pinMode(potiPin, INPUT);
   
    // ledc (LED Control) pins setup, used as PWMs for motors
    ledcAttachPin(climbMotorFPin, 1); // F means forward
@@ -26,17 +32,22 @@ void setup() {
 }
 
 void loop() {
+  button = digitalRead(buttonPin);
+  poti = analogRead(potiPin);
+  motorSpeed = map(poti, 0, 4095, minMotorSpeed, maxMotorSpeed);
+  
   Serial.print("Button: ");
   Serial.print(button);
+  Serial.print(" Poti: ");
+  Serial.print(poti);
   Serial.print(" Motor: ");
   Serial.println(motorOn);
   
-  button = digitalRead(buttonPin);
   if (button == 1 && buttonLast == 0) // Button has just been pressed
     motorOn = !motorOn;               // Turn the motor on if off, turn motor off if on
 
   if (motorOn) {
-    ledcWrite(1, 255);
+    ledcWrite(1, motorSpeed);
     ledcWrite(2, 0);
   } else {
     ledcWrite(1, 0);

--- a/mse2202-project/tuning.h
+++ b/mse2202-project/tuning.h
@@ -16,10 +16,10 @@ struct driveManeuver {
 // Navigation Route
 const driveManeuver driveManeuvers[] = {
   {DRIVE, 30},
-  {TURN, 90}
-  {DRIVE, 30},
-  {TURN, 90},
-  {DRIVE, 25}
+//  {TURN, 90},
+//  {DRIVE, 30},
+//  {TURN, 90},
+//  {DRIVE, 25}
 };
 
 const bool cwNavigation = true;

--- a/mse2202-project/tuning.h
+++ b/mse2202-project/tuning.h
@@ -16,7 +16,7 @@ struct driveManeuver {
 // Navigation Route
 const driveManeuver driveManeuvers[] = {
   {DRIVE, 30},
-//  {TURN, 90},
+  {TURN, 90},
 //  {DRIVE, 30},
 //  {TURN, 90},
 //  {DRIVE, 25}


### PR DESCRIPTION
# Overview
In this PR, we're adding the climb state machine. This branch had already been updated from master, so it had the drive code and was being used to test the robot for the videos. It's being merged into main now.

# Summary of Changes
- Add climb state machine in `climb.h` with states `UP`, `DOWN`, `STOPPED`, and `HOLD`
- Add `bool readyToClimb()` function to communicate when the robot is ready to climb at the end of navigation

# Testing
- A DC motor should be attached to the MX805 motor driver
    - +/- pins should be connected to 5V AND GRND
    - INT1/INT2 should be connected to pin 23 and pin 25
- The constant variable `currentThreshold` in `climb.h` should be tuned so that the climb motor stops when it's stalled

# Resources
N/A 